### PR TITLE
Add ground reaction force tracking.

### DIFF
--- a/src/solve.py
+++ b/src/solve.py
@@ -59,7 +59,7 @@ SUBJECT_MASS = 70.0  # kg of subject from trial 20, TODO: extract from metadata
 USE_WINTER_DATA = False  # if we want to track Winter's gait data
 # Remove parts of the objective by setting to integer 0.
 WANG = 1000.0  # weight of mean squared angle tracking error (in rad)
-WGRF = 1.0  # weight of mean squared GRF tracking error (in Newtons)
+WGRF = 0.005  # weight of mean squared GRF tracking error (in Newtons)
 WMAR = 0  # weight of mean squared marker tracking error (in meters)
 WREG = 1e-6  # weight of mean squared time derivatives
 WTOR = 1000.0  # weight of the mean squared torque (in kNm) objective
@@ -81,9 +81,12 @@ h = duration/(NUM_NODES - 1)
 
 # Derive the equations of motion
 logger.info('Deriving the equations of motion.')
-syms = derive_equations_of_motion(prevent_ground_penetration=False,
-                                  treadmill=True, hand_of_god=False,
-                                  stiffness_exp=STIFFNESS_EXP)
+syms = derive_equations_of_motion(
+    prevent_ground_penetration=False,
+    treadmill=True,
+    hand_of_god=False,
+    stiffness_exp=STIFFNESS_EXP,
+)
 eom = syms.equations_of_motion
 logger.info('Number of operations in eom: {}'.format(sm.count_ops(eom)))
 
@@ -98,7 +101,7 @@ if WMAR != 0:
     eom = eom.col_join(sm.Matrix(marker_eqs))
     mar_data = marker_df[marker_labels].values.T.flatten()
 
-# Ground reaction forces are in units XXXX
+# Ground reaction forces are in units Newtons
 if WGRF != 0:
     grf_syms, grf_eqs, grf_labels = generate_grf_equations(syms)
     eom = eom.col_join(grf_eqs)
@@ -115,6 +118,7 @@ if WGRF != 0:
 qax, qay, qa, qb, qc, qd, qe, qf, qg = syms.coordinates
 uax, uay, ua, ub, uc, ud, ue, uf, ug = syms.speeds
 Tb, Tc, Td, Te, Tf, Tg, v = syms.specifieds
+Frx, Fry, Flx, Fly = grf_syms
 reg_syms = syms.states + syms.joint_torques
 num_states = len(syms.states)
 
@@ -167,7 +171,7 @@ bounds.update({k: (-np.deg2rad(400.0), np.deg2rad(400.0))
 # all joint torques
 bounds.update({k: (-600.0, 600.0)
                for k in [Tb, Tc, Td, Te, Tf, Tg]})
-# TODO : Add bounds for marker trajectories.
+# TODO : Add bounds for marker trajectories and ground reaction forces.
 
 # To enforce a half period, set the right leg's angles at the initial time to
 # be equal to the left leg's angles at the final time and vice versa. The same
@@ -213,7 +217,16 @@ if WMAR != 0:
         )
         instance_constraints += con
 
-# TODO : add periodcity for ground reaction forces
+# When tracking ground reaction forces, simulation must be periodic too
+if WGRF != 0:
+    con = (
+        Flx.func(0*h) - Frx.func(duration),
+        Frx.func(0*h) - Flx.func(duration),
+        Fly.func(0*h) - Fry.func(duration),
+        Fry.func(0*h) - Fly.func(duration),
+    )
+    instance_constraints += con
+
 
 def obj(prob, free, obj_show=False):
     """
@@ -240,8 +253,8 @@ def obj(prob, free, obj_show=False):
     if WANG != 0:
         ang_vals = extract_values(prob, free, *syms.joint_angles,
                                   slice=(0, -1))
-        f_track_ang = WANG*np.sum((ang_vals - ang_data)**2)/len(ang_vals)
-        f_tot += f_track_ang
+        f_ang = WANG*np.sum((ang_vals - ang_data)**2)/len(ang_vals)
+        f_tot += f_ang
 
     # smooth all regularization trajectories
     if WREG != 0:
@@ -259,19 +272,19 @@ def obj(prob, free, obj_show=False):
     # minimize mean ground reaction force tracking error
     if WGRF != 0:
         grf_vals = extract_values(prob, free, *grf_syms, slice=(0, -1))
-        f_track_grf = WGRF*np.sum((grf_vals - grf_data)**2)/len(grf_vals)
-        f_tot += f_track_grf
+        f_grf = WGRF*np.sum((grf_vals - grf_data)**2)/len(grf_vals)
+        f_tot += f_grf
 
     if obj_show:
         msg = (f"   obj: {f_tot:.3f} = {f_tor:.3f}(torque)")
         if WREG != 0:
             msg += f" + {f_reg:.3f}(reg)"
         if WANG != 0:
-            msg += f" + {f_track_ang:.3f}(angle)"
+            msg += f" + {f_ang:.3f}(angle)"
         if WMAR != 0:
             msg += f" + {f_mar:.3f}(marker)"
         if WGRF != 0:
-            msg += f" + {f_track_grf:.3f}(grf)"
+            msg += f" + {f_grf:.3f}(grf)"
         print(msg)
 
     return f_tot

--- a/src/solve.py
+++ b/src/solve.py
@@ -30,6 +30,7 @@ from utils import (
     extract_values,
     extract_values_diff,
     fill_free,
+    generate_grf_equations,
     generate_marker_equations,
     load_sample_data,
     load_winter_data,
@@ -58,7 +59,8 @@ SUBJECT_MASS = 70.0  # kg of subject from trial 20, TODO: extract from metadata
 USE_WINTER_DATA = False  # if we want to track Winter's gait data
 # Remove parts of the objective by setting to integer 0.
 WANG = 1000  # weight of mean squared angle tracking error (in rad)
-WMAR = 0.0  # weight of mean squared marker tracking error (in meters)
+WGRF = 10  # weight of mean squared GRF tracking error (in Newtons)
+WMAR = 100  # weight of mean squared marker tracking error (in meters)
 WREG = 1e-6  # weight of mean squared time derivatives
 WTOR = 1000.0  # weight of the mean squared torque (in kNm) objective
 
@@ -95,6 +97,11 @@ if WMAR != 0:
     marker_coords, marker_eqs, marker_labels = generate_marker_equations(syms)
     eom = eom.col_join(sm.Matrix(marker_eqs))
     mar_data = marker_df[marker_labels].values.T.flatten()
+
+if WGRF != 0:
+    grf_syms, grf_eqs, grf_labels = generate_grf_equations(syms)
+    eom = eom.col_join(grf_eqs)
+    grf_data = kinetic_df[grf_labels].values.T.flatten()
 
 # The generalized coordinates are the hip lateral position qax and veritcal
 # position qay, the trunk angle with respect to vertical qa and the relative
@@ -205,6 +212,8 @@ if WMAR != 0:
         )
         instance_constraints += con
 
+# TODO : add periodcity for ground reaction forces
+
 def obj(prob, free, obj_show=False):
     """
     Objective function::
@@ -213,6 +222,7 @@ def obj(prob, free, obj_show=False):
           + WANG*mean(joint_angle_error**2)
           + WREG*mean((dx/dt)**2)
           + WMAR*mean(marker_error**2)
+          + WGRF*mean(grf_error**2)
 
     The final node is excluded from all means. Due to symmetry and
     periodicity constraints, it is the mirror image of the first node,
@@ -225,12 +235,12 @@ def obj(prob, free, obj_show=False):
 
     f_tot = f_tor
 
+    # minimize mean angle tracking error
     if WANG != 0:
-        # minimize mean angle tracking error
         ang_vals = extract_values(prob, free, *syms.joint_angles,
                                   slice=(0, -1))
-        f_track = WANG*np.sum((ang_vals - ang_data)**2)/len(ang_vals)
-        f_tot += f_track
+        f_track_ang = WANG*np.sum((ang_vals - ang_data)**2)/len(ang_vals)
+        f_tot += f_track_ang
 
     # smooth all regularization trajectories
     if WREG != 0:
@@ -245,14 +255,22 @@ def obj(prob, free, obj_show=False):
         f_mar = WMAR*np.sum((mar_vals - mar_data)**2)/len(mar_vals)
         f_tot += f_mar
 
+    # minimize mean ground reaction force tracking error
+    if WGRF != 0:
+        grf_vals = extract_values(prob, free, *grf_syms, slice=(0, -1))
+        f_track_grf = WGRF*np.sum((grf_vals - grf_data)**2)/len(grf_vals)
+        f_tot += f_track_grf
+
     if obj_show:
         msg = (f"   obj: {f_tot:.3f} = {f_tor:.3f}(torque)")
         if WREG != 0:
             msg += f" + {f_reg:.3f}(reg)"
         if WANG != 0:
-            msg += f" + {f_track:.3f}(angle)"
+            msg += f" + {f_track_ang:.3f}(angle)"
         if WMAR != 0:
             msg += f" + {f_mar:.3f}(marker)"
+        if WGRF != 0:
+            msg += f" + {f_track_grf:.3f}(grf)"
         print(msg)
 
     return f_tot
@@ -271,7 +289,6 @@ def obj_grad(prob, free):
         fill_free(prob, grad,
                   2.0*WANG*(ang_vals - ang_data)/len(ang_vals),
                   *syms.joint_angles, slice=(0, -1))
-
     if WREG != 0:
         # NOTE : The regularization should be added on top of the tor_vals and
         # ang_vals.
@@ -286,6 +303,12 @@ def obj_grad(prob, free):
         fill_free(prob, grad,
                   2.0*WMAR*(mar_vals - mar_data)/len(mar_vals),
                   *marker_coords, slice=(0, -1))
+
+    if WGRF != 0:
+        grf_vals = extract_values(prob, free, *grf_syms, slice=(0, -1))
+        fill_free(prob, grad,
+                  2.0*WGRF*(grf_vals - grf_data)/len(grf_vals),
+                  *grf_syms, slice=(0, -1))
 
     return grad
 
@@ -349,6 +372,9 @@ if WMAR != 0:
     # coordinates.
     mar_traj = np.zeros((len(marker_coords), NUM_NODES))
     initial_guess = np.concatenate((initial_guess, mar_traj))
+if WGRF != 0:
+    grf_traj = np.zeros((len(grf_syms), NUM_NODES))
+    initial_guess = np.concatenate((initial_guess, grf_traj))
 initial_guess = initial_guess.flatten()  # make a single row vector
 if SEED:
     np.random.seed(SEED)  # this makes the result reproducible
@@ -406,7 +432,15 @@ tor[:, [0, 2]] = -tor[:, [0, 2]]
 # Generate plots and animations
 if WMAR != 0:
     # TODO : Extract the measured joint torques from the Winter's data also.
-    tor_meas = kinetic_df.values
+    tor_cols = [
+        'Right.Hip.Flexion.Moment',
+        'Right.Knee.Flexion.Moment',
+        'Right.Ankle.PlantarFlexion.Moment',
+        'Left.Hip.Flexion.Moment',
+        'Left.Knee.Flexion.Moment',
+        'Left.Ankle.PlantarFlexion.Moment',
+    ]
+    tor_meas = kinetic_df[tor_cols].values
     tor_meas = np.vstack((tor_meas[:, 0:3],
                           tor_meas[:, 3:6],
                           tor_meas[1, 0:3]))

--- a/src/solve.py
+++ b/src/solve.py
@@ -58,9 +58,9 @@ STIFFNESS_EXP = 2  # exponent of the contact stiffness force
 SUBJECT_MASS = 70.0  # kg of subject from trial 20, TODO: extract from metadata
 USE_WINTER_DATA = False  # if we want to track Winter's gait data
 # Remove parts of the objective by setting to integer 0.
-WANG = 1000  # weight of mean squared angle tracking error (in rad)
-WGRF = 10  # weight of mean squared GRF tracking error (in Newtons)
-WMAR = 100  # weight of mean squared marker tracking error (in meters)
+WANG = 1000.0  # weight of mean squared angle tracking error (in rad)
+WGRF = 1.0  # weight of mean squared GRF tracking error (in Newtons)
+WMAR = 0  # weight of mean squared marker tracking error (in meters)
 WREG = 1e-6  # weight of mean squared time derivatives
 WTOR = 1000.0  # weight of the mean squared torque (in kNm) objective
 
@@ -94,10 +94,11 @@ for i in range(9):
 
 # Markers are in units meters, so no scaling applied
 if WMAR != 0:
-    marker_coords, marker_eqs, marker_labels = generate_marker_equations(syms)
+    marker_syms, marker_eqs, marker_labels = generate_marker_equations(syms)
     eom = eom.col_join(sm.Matrix(marker_eqs))
     mar_data = marker_df[marker_labels].values.T.flatten()
 
+# Ground reaction forces are in units XXXX
 if WGRF != 0:
     grf_syms, grf_eqs, grf_labels = generate_grf_equations(syms)
     eom = eom.col_join(grf_eqs)
@@ -202,7 +203,7 @@ instance_constraints = (
 
 # When tracking markers, simulated marker trajectories must be periodic too
 if WMAR != 0:
-    for (lx, ly, rx, ry) in itertools.zip_longest(*[iter(marker_coords)]*4):
+    for (lx, ly, rx, ry) in itertools.zip_longest(*[iter(marker_syms)]*4):
         # group per marker: (ank_lx(t), ank_ly(t), ank_rx(t), ank_ry(t))
         con = (
             lx.func(0*h) - rx.func(duration),
@@ -251,7 +252,7 @@ def obj(prob, free, obj_show=False):
     # minimize mean marker tracking error
     if WMAR != 0:
         # vals -> shape(num_markers*(num_nodes - 1), 1)
-        mar_vals = extract_values(prob, free, *marker_coords, slice=(0, -1))
+        mar_vals = extract_values(prob, free, *marker_syms, slice=(0, -1))
         f_mar = WMAR*np.sum((mar_vals - mar_data)**2)/len(mar_vals)
         f_tot += f_mar
 
@@ -299,10 +300,10 @@ def obj_grad(prob, free):
         fill_free(prob, grad, reg_grad, *reg_syms, slice=(1, None), add=True)
 
     if WMAR != 0:
-        mar_vals = extract_values(prob, free, *marker_coords, slice=(0, -1))
+        mar_vals = extract_values(prob, free, *marker_syms, slice=(0, -1))
         fill_free(prob, grad,
                   2.0*WMAR*(mar_vals - mar_data)/len(mar_vals),
-                  *marker_coords, slice=(0, -1))
+                  *marker_syms, slice=(0, -1))
 
     if WGRF != 0:
         grf_vals = extract_values(prob, free, *grf_syms, slice=(0, -1))
@@ -370,7 +371,7 @@ initial_guess = tile_standing(standing_sol, NUM_NODES, num_angles, num_states)
 if WMAR != 0:
     # TODO : The marker positions could be calculated from the generalized
     # coordinates.
-    mar_traj = np.zeros((len(marker_coords), NUM_NODES))
+    mar_traj = np.zeros((len(marker_syms), NUM_NODES))
     initial_guess = np.concatenate((initial_guess, mar_traj))
 if WGRF != 0:
     grf_traj = np.zeros((len(grf_syms), NUM_NODES))
@@ -430,6 +431,7 @@ dat[:, 1] = -dat[:, 1]
 tor[:, [0, 2]] = -tor[:, [0, 2]]
 
 # Generate plots and animations
+tor_meas, grf_sol, grf_meas = None, None, None
 if WMAR != 0:
     # TODO : Extract the measured joint torques from the Winter's data also.
     tor_cols = [
@@ -446,12 +448,23 @@ if WMAR != 0:
                           tor_meas[1, 0:3]))
     tor_meas[:, 0] = -tor_meas[:, 0]  # hip
     tor_meas[:, 1] = -tor_meas[:, 1]  # knee
-    plot_joint_comparison(t, ang, tor, dat, torques_meas=tor_meas)
-else:
-    plot_joint_comparison(t, ang, tor, dat)
+
+if WGRF != 0:
+    # Frx(t), Fry(t), Flx(t), Fly(t)
+    # N-1 x 4
+    grf_sol = extract_values(prob, solution, *grf_syms,
+                             slice=(0, -1)).reshape(len(grf_syms),
+                                                    NUM_NODES-1).transpose()
+    grf_sol = np.vstack((grf_sol[:, 0:2], grf_sol[:, 2:4], grf_sol[1, 0:2]))
+    grf_meas = kinetic_df[grf_labels].values
+    grf_meas = np.vstack((grf_meas[:, 0:2], grf_meas[:, 2:4], grf_meas[1,
+                                                                       0:2]))
+
+plot_joint_comparison(t, ang, tor, dat, torques_meas=tor_meas, grf=grf_sol,
+                      grf_meas=grf_meas)
 
 if WMAR != 0:
-    plot_marker_comparison(marker_coords, marker_labels, marker_df, prob,
+    plot_marker_comparison(marker_syms, marker_labels, marker_df, prob,
                            solution)
 
 plt.show()

--- a/src/solve.py
+++ b/src/solve.py
@@ -59,7 +59,7 @@ SUBJECT_MASS = 70.0  # kg of subject from trial 20, TODO: extract from metadata
 USE_WINTER_DATA = False  # if we want to track Winter's gait data
 # Remove parts of the objective by setting to integer 0.
 WANG = 1000.0  # weight of mean squared angle tracking error (in rad)
-WGRF = 0.005  # weight of mean squared GRF tracking error (in Newtons)
+WGRF = 0  # weight of mean squared GRF tracking error (in Newtons)
 WMAR = 0  # weight of mean squared marker tracking error (in meters)
 WREG = 1e-6  # weight of mean squared time derivatives
 WTOR = 1000.0  # weight of the mean squared torque (in kNm) objective
@@ -118,7 +118,6 @@ if WGRF != 0:
 qax, qay, qa, qb, qc, qd, qe, qf, qg = syms.coordinates
 uax, uay, ua, ub, uc, ud, ue, uf, ug = syms.speeds
 Tb, Tc, Td, Te, Tf, Tg, v = syms.specifieds
-Frx, Fry, Flx, Fly = grf_syms
 reg_syms = syms.states + syms.joint_torques
 num_states = len(syms.states)
 
@@ -219,6 +218,7 @@ if WMAR != 0:
 
 # When tracking ground reaction forces, simulation must be periodic too
 if WGRF != 0:
+    Frx, Fry, Flx, Fly = grf_syms
     con = (
         Flx.func(0*h) - Frx.func(duration),
         Frx.func(0*h) - Flx.func(duration),
@@ -463,6 +463,7 @@ if WMAR != 0:
     tor_meas[:, 1] = -tor_meas[:, 1]  # knee
 
 if WGRF != 0:
+    # TODO : Extract the GRFs from the Winter's data also.
     # Frx(t), Fry(t), Flx(t), Fly(t)
     # N-1 x 4
     grf_sol = extract_values(prob, solution, *grf_syms,
@@ -470,8 +471,7 @@ if WGRF != 0:
                                                     NUM_NODES-1).transpose()
     grf_sol = np.vstack((grf_sol[:, 0:2], grf_sol[:, 2:4], grf_sol[1, 0:2]))
     grf_meas = kinetic_df[grf_labels].values
-    grf_meas = np.vstack((grf_meas[:, 0:2], grf_meas[:, 2:4], grf_meas[1,
-                                                                       0:2]))
+    grf_meas = np.vstack((grf_meas[:, 0:2], grf_meas[:, 2:4], grf_meas[1, 0:2]))
 
 plot_joint_comparison(t, ang, tor, dat, torques_meas=tor_meas, grf=grf_sol,
                       grf_meas=grf_meas)

--- a/src/utils.py
+++ b/src/utils.py
@@ -383,6 +383,53 @@ def generate_marker_equations(symbolics):
 
     return variables, equations, data_labels
 
+def generate_grf_equations(symbolics):
+    """Returns the equations for the x and y ground reaction forces to track.
+
+    Parameters
+    ==========
+    symbolics : pygait2d.derive.Symbolics
+        Dataclass containing the symbolic model.
+
+    Returns
+    =======
+    variables : list of Symbol
+        SymPy symbols for the x and y measure numbers of the resultant force on
+        each foot.
+    equations : list of Expr
+        SymPy expressions representing the equations for the x and y measure
+        numbers of the resultant force on each foot.
+    labels : list of str
+        List of measured ground reaction force labels that correspond to the
+        model ground reaction forces to track.
+
+    """
+    grf = symbolics.ground_reaction_forces
+    N = symbolics.inertial_frame
+
+    right_vars = sm.Matrix(time_varying('Frx, Fry'))
+    left_vars = sm.Matrix(time_varying('Flx, Fly'))
+
+    variables = right_vars.col_join(left_vars)[:]
+
+    right_force = grf['Right Foot heel'] + grf['Right Foot toe']
+    left_force = grf['Left Foot heel'] + grf['Left Foot toe']
+
+    right_eqs = right_vars - right_force.to_matrix(N)[:2, :]
+    left_eqs = left_vars - left_force.to_matrix(N)[:2, :]
+    equations = right_eqs.col_join(left_eqs)
+
+    # FP1 is left
+    # FP2 is right
+    labels = [
+        'FP2.ForX',
+        'FP2.ForY',
+        'FP1.ForX',
+        'FP1.ForY',
+    ]
+
+    return variables, equations, labels
+
 
 def extract_gait_cycle(df, number):
     """Returns a single gait cycle as a data frame from a measurement data
@@ -556,12 +603,12 @@ def load_sample_data(num_nodes, gait_cycle_number=100):
     marker_vals = df[markers].values
 
     kinetics = [
-        #'FP1.ForX',
-        #'FP1.ForY',
-        #'FP1.ForZ',
-        #'FP2.ForX',
-        #'FP2.ForY',
-        #'FP2.ForZ',
+        'FP1.ForX',
+        'FP1.ForY',
+        'FP1.ForZ',
+        'FP2.ForX',
+        'FP2.ForY',
+        'FP2.ForZ',
         'Right.Hip.Flexion.Moment',
         'Right.Knee.Flexion.Moment',
         'Right.Ankle.PlantarFlexion.Moment',

--- a/src/utils.py
+++ b/src/utils.py
@@ -192,19 +192,15 @@ def animate(symbolics, xs, rs, h, speed, times, par_map, stiffness_exp):
 
     # show ground reaction force vectors at the heels and toes, scaled to
     # visually reasonable length
-    v = symbolics.specifieds[-1]
-    scene.add_vector(contact_force(rfoot.toe, ground, origin, v,
-                                   stiffness_exp=stiffness_exp)/600.0,
-                     rfoot.toe, color="tab:blue")
-    scene.add_vector(contact_force(rfoot.heel, ground, origin, v,
-                                   stiffness_exp=stiffness_exp)/600.0,
-                     rfoot.heel, color="tab:blue")
-    scene.add_vector(contact_force(lfoot.toe, ground, origin, v,
-                                   stiffness_exp=stiffness_exp)/600.0,
-                     lfoot.toe, color="tab:blue")
-    scene.add_vector(contact_force(lfoot.heel, ground, origin, v,
-                                   stiffness_exp=stiffness_exp)/600.0,
-                     lfoot.heel, color="tab:blue")
+    grf = symbolics.ground_reaction_forces
+    scene.add_vector(grf['Right Foot toe']/600.0, rfoot.toe,
+                     color="tab:blue")
+    scene.add_vector(grf['Right Foot heel']/600.0, rfoot.heel,
+                     color="tab:blue")
+    scene.add_vector(grf['Left Foot toe']/600.0, lfoot.toe,
+                     color="tab:blue")
+    scene.add_vector(grf['Left Foot heel']/600.0, lfoot.heel,
+                     color="tab:blue")
 
     scene.lambdify_system(symbolics.states + symbolics.specifieds +
                           symbolics.constants)
@@ -230,18 +226,12 @@ def animate(symbolics, xs, rs, h, speed, times, par_map, stiffness_exp):
 
     eval_rforce = sm.lambdify(
         symbolics.states + symbolics.specifieds + symbolics.constants,
-        (contact_force(rfoot.toe, ground, origin, v,
-                       stiffness_exp=stiffness_exp) +
-         contact_force(rfoot.heel, ground, origin, v,
-                       stiffness_exp=stiffness_exp)).to_matrix(ground),
+        (grf['Right Foot heel'] + grf['Right Foot toe']).to_matrix(ground),
         cse=True)
 
     eval_lforce = sm.lambdify(
         symbolics.states + symbolics.specifieds + symbolics.constants,
-        (contact_force(lfoot.toe, ground, origin, v,
-                       stiffness_exp=stiffness_exp) +
-         contact_force(lfoot.heel, ground, origin, v,
-                       stiffness_exp=stiffness_exp)).to_matrix(ground),
+        (grf['Left Foot heel'] + grf['Left Foot toe']).to_matrix(ground),
         cse=True)
 
     rforces = np.array([eval_rforce(*gci).squeeze() for gci in gait_cycle.T])


### PR DESCRIPTION
Fixes #33

@tvdbogert this adds basic GRF tracking using the same method I used for the markers. It runs, but not yet giving a better solution than without.

TODO

- [x] Figure out if scaling is needed because the eom is scaled.
- [x] Double check units are the same in the data (e.g. not scaled by mass)
- [x] Check sign of forces.